### PR TITLE
feat: allow selecting enemy hero

### DIFF
--- a/Assets/CharacterSelection/CharacterButton.cs
+++ b/Assets/CharacterSelection/CharacterButton.cs
@@ -7,14 +7,12 @@ public class CharacterButton : MonoBehaviour
     public Button button;
     public Image iconImage;
     private CharacterSelectUI ui;
-    public GameObject selectedHero;
 
     public void Init(CharacterData data, CharacterSelectUI selectUI)
     {
         characterData = data;
         ui = selectUI;
         iconImage.sprite = data.characterIcon;
-        selectedHero = data.characterPrefab;
         button.onClick.AddListener(OnClick);
     }
 
@@ -22,6 +20,6 @@ public class CharacterButton : MonoBehaviour
     {
         ui.ShowCharacter(characterData);
         CharacterSelectionMenu menu = FindObjectOfType<CharacterSelectionMenu>();
-        menu.SelectHero(selectedHero);
+        menu.SelectHero(characterData.characterPrefab);
     }
 }

--- a/Assets/CharacterSelection/CharacterSelectionMenu.cs
+++ b/Assets/CharacterSelection/CharacterSelectionMenu.cs
@@ -3,46 +3,73 @@ using UnityEngine.SceneManagement;
 
 public class CharacterSelectionMenu : MonoBehaviour
 {
-    public GameObject[] enemyHeroes;
+    public GameObject playerSelectionPanel;
+    public GameObject enemySelectionPanel;
 
     private GameObject selectedHero;
+    private bool selectingEnemy;
 
     public void SelectHero(GameObject hero)
     {
         Debug.LogWarning("Héros sélectionné : " + hero.name);
         selectedHero = hero;
+
+        if (selectingEnemy)
+            GameManager.Instance.enemySelected = hero;
+        else
+            GameManager.Instance.heroSelected = hero;
     }
 
     public void PlayGame()
     {
-        var deckSelection = DeckSelection.Instance;
-        int deckCount = 0;
-        if (deckSelection != null && deckSelection.selectedPrefabs != null && deckSelection.selectedPrefabs.Count > 0)
-            deckCount = deckSelection.selectedPrefabs.Count;
+        if (!selectingEnemy)
+        {
+            var deckSelection = DeckSelection.Instance;
+            int deckCount = 0;
+            if (deckSelection != null && deckSelection.selectedPrefabs != null && deckSelection.selectedPrefabs.Count > 0)
+                deckCount = deckSelection.selectedPrefabs.Count;
+            else
+            {
+                var fullDeck = FindObjectOfType<FullDeckGenerator>();
+                deckCount = fullDeck != null ? fullDeck.defaultDeckPrefabs.Count : 0;
+            }
+
+            if (deckCount < 15)
+            {
+                Debug.LogWarning($"Votre deck contient {deckCount} cartes ; il doit en contenir au moins 15 pour jouer.");
+                return;
+            }
+
+            if (selectedHero == null)
+            {
+                Debug.LogWarning("Aucun héros sélectionné !");
+                return;
+            }
+
+            if (playerSelectionPanel != null)
+                playerSelectionPanel.SetActive(false);
+            if (enemySelectionPanel != null)
+                enemySelectionPanel.SetActive(true);
+            else
+                SceneManager.LoadScene("EnemyCharacterSelection");
+
+            selectingEnemy = true;
+            selectedHero = null;
+            Debug.LogWarning("Sélectionnez le héros ennemi.");
+        }
         else
         {
-            var fullDeck = FindObjectOfType<FullDeckGenerator>();
-            deckCount = fullDeck != null ? fullDeck.defaultDeckPrefabs.Count : 0;
+            if (selectedHero == null)
+            {
+                Debug.LogWarning("Aucun héros ennemi sélectionné !");
+                return;
+            }
+
+            Debug.LogWarning("Play game with heroes : " + GameManager.Instance.heroSelected.name + " vs " + selectedHero.name);
+            SceneManager.LoadScene("Game");
         }
-
-        if (deckCount < 15)
-        {
-            Debug.LogWarning($"Votre deck contient {deckCount} cartes ; il doit en contenir au moins 15 pour jouer.");
-            return;
-        }
-
-        if (selectedHero == null)
-        {
-            Debug.LogWarning("Aucun héros sélectionné !");
-            return;
-        }
-
-        Debug.LogWarning("Play game with hero : " + selectedHero.name);
-        GameManager.Instance.heroSelected = selectedHero;
-        GameManager.Instance.enemySelected = enemyHeroes[Random.Range(0, enemyHeroes.Length)];
-
-        SceneManager.LoadScene("Game");
     }
+
     public void OpenDeckBuilder()
     {
         SceneManager.LoadScene("DeckBuilder");

--- a/Assets/EnemyCharacterSelection.unity
+++ b/Assets/EnemyCharacterSelection.unity
@@ -595,7 +595,7 @@ MonoBehaviour:
     m_HorizontalOverflow: 0
     m_VerticalOverflow: 0
     m_LineSpacing: 1
-  m_Text: Votre héros
+  m_Text: Héros ennemi
 --- !u!222 &710949165
 CanvasRenderer:
   m_ObjectHideFlags: 0
@@ -1113,7 +1113,7 @@ GameObject:
   - component: {fileID: 1749429188}
   - component: {fileID: 1749429187}
   m_Layer: 5
-  m_Name: PlayerCharacterSelectionCanvas
+  m_Name: EnemyCharacterSelectionCanvas
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0

--- a/Assets/EnemyCharacterSelection.unity.meta
+++ b/Assets/EnemyCharacterSelection.unity.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 48edc90491cb4c1ea66550f778003db7
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary
- add selectingEnemy state and handle player vs enemy hero assignment
- support enemy hero selection before starting game
- duplicate selection scene for enemy and update labels

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b5a3c13500832ca0681ca59b96c245